### PR TITLE
fixes "uninitialized constant M9t" error

### DIFF
--- a/lib/m9t.rb
+++ b/lib/m9t.rb
@@ -22,9 +22,9 @@
 #++
 
 # encoding: utf-8
+module M9t; end
+
 libs = %w(i18n base direction distance pressure speed temperature version)
 libs.each do |library|
   require "m9t/#{library}"
 end
-
-module M9t; end


### PR DESCRIPTION
Without this change, a "NameError: uninitialized constant M9t" error is generated with Rails 4.2.x
